### PR TITLE
Rplace symbol to string

### DIFF
--- a/Formula/gem-src.rb
+++ b/Formula/gem-src.rb
@@ -7,7 +7,7 @@ class GemSrc < Formula
   head "https://github.com/amatsuda/gem-src.git"
 
   bottle :unneeded
-  depends_on :rbenv
+  depends_on "rbenv"
 
   def install
     prefix.install Dir["*"]


### PR DESCRIPTION
```
Warning: Calling 'depends_on :rbenv' is deprecated!
Use 'depends_on "rbenv"' instead.
/usr/local/Homebrew/Library/Taps/1syo/homebrew-formulae/Formula/gem-src.rb:10:in `<class:GemSrc>'
Please report this to the 1syo/formulae tap!
```